### PR TITLE
This commit fixed issue #2

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,50 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="47" name="Python" />
+      </Languages>
+    </inspection_tool>
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredPackages">
+        <value>
+          <list size="10">
+            <item index="0" class="java.lang.String" itemvalue="scipy" />
+            <item index="1" class="java.lang.String" itemvalue="scikit-learn" />
+            <item index="2" class="java.lang.String" itemvalue="python-magic" />
+            <item index="3" class="java.lang.String" itemvalue="re" />
+            <item index="4" class="java.lang.String" itemvalue="matplotlib" />
+            <item index="5" class="java.lang.String" itemvalue="json" />
+            <item index="6" class="java.lang.String" itemvalue="requests" />
+            <item index="7" class="java.lang.String" itemvalue="numpy" />
+            <item index="8" class="java.lang.String" itemvalue="argparse" />
+            <item index="9" class="java.lang.String" itemvalue="pickle" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E101" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N806" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="urllib.request" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/patchesandmissedmatches-1.iml" filepath="$PROJECT_DIR$/.idea/patchesandmissedmatches-1.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/patchesandmissedmatches-1.iml
+++ b/.idea/patchesandmissedmatches-1.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Examples/Examples.ipynb
+++ b/Examples/Examples.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "6333ab50",
    "metadata": {},
    "outputs": [],
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "00f9ba55",
    "metadata": {},
    "outputs": [],
@@ -82,7 +82,7 @@
     "\"\"\"\n",
     "    Read from list\n",
     "\"\"\"\n",
-    "token_file = 'tokens.txt'\n",
+    "token_file = '/Users/businge/Desktop/00github_tokens/github_tokens.txt'\n",
     "\n",
     "token_list = list()\n",
     "with open(token_file) as f:\n",
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "b8c4e4e0",
    "metadata": {},
    "outputs": [],
@@ -175,14 +175,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "dad6162a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# data = ('1','learningequality/pycaption', 'pbs/pycaption', '', '', token_list)\n",
-    "# data = ('2','apache/kafka', 'linkedin/kafka', '', '', token_list)\n",
-    "data = ('3','hzdg/django-enumfields', 'druids/django-choice-enumfields', '', '', token_list)"
+    "data = ('2','apache/kafka', 'linkedin/kafka', '', '', token_list)\n",
+    "# data = ('3','hzdg/django-enumfields', 'druids/django-choice-enumfields', '', '', token_list)"
    ]
   },
   {
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "0eadcd03",
    "metadata": {},
    "outputs": [],
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "8f90fd6d",
    "metadata": {},
    "outputs": [
@@ -222,11 +222,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The divergence_date of the repository druids/django-choice-enumfields is 2019-03-01T10:01:18Z and the cut_off_date is 2021-12-27T16:08:41Z.\n",
+      "The divergence_date of the repository linkedin/kafka is 2021-08-10T19:25:59Z and the cut_off_date is 2022-09-28T19:19:01Z.\n",
       "The variant2 is ==>\n",
-      "\t Ahead by 21 patches\n",
-      "\t Behind by 40 patches\n",
-      "Select an interval within the period [2019-03-01T10:01:18Z, 2021-12-27T16:08:41Z] to limit the patches being checked.\n"
+      "\t Ahead by 367 patches\n",
+      "\t Behind by 1216 patches\n",
+      "Select an interval within the period [2021-08-10T19:25:59Z, 2022-09-28T19:19:01Z] to limit the patches being checked.\n"
      ]
     }
    ],
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "5bd56c0c",
    "metadata": {},
    "outputs": [
@@ -256,14 +256,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracting patches between 2019-03-01T10:01:18Z and 2021-12-27T16:08:41Z...\n",
-      "pr_patch_ml: [109, 103, 102]\n",
-      "pr_title_ml: ['fix enumsupportserializermixin for non-editable fields', 'readme fix rollup', 'fix ci']\n"
+      "Extracting patches between 2021-09-28T18:25:46Z and 2022-01-26T07:22:46Z...\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=1&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=2&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=3&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=4&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=5&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=6&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=7&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=8&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=9&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=10&per_page=100&state=closed&sort=created&direction=desc\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=11&per_page=100&state=closed&sort=created&direction=desc\n",
+      "string indices must be integers\n",
+      "string indices must be integers\n",
+      "https://api.github.com/repos/apache/kafka/pulls?page=12&per_page=100&state=closed&sort=created&direction=desc\n"
      ]
     }
    ],
    "source": [
-    "prs_source = example.extractPatches('2019-03-01T10:01:18Z', '2021-12-27T16:08:41Z')"
+    "prs_source = example.extractPatches('2021-09-28T18:25:46Z', '2022-01-26T07:22:46Z')"
    ]
   },
   {
@@ -280,63 +292,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "5707ef84",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Patch number</th>\n",
-       "      <th>Patch title</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>109</td>\n",
-       "      <td>fix enumsupportserializermixin for non-editabl...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>103</td>\n",
-       "      <td>readme fix rollup</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>102</td>\n",
-       "      <td>fix ci</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Patch number                                        Patch title\n",
-       "0           109  fix enumsupportserializermixin for non-editabl...\n",
-       "1           103                                  readme fix rollup\n",
-       "2           102                                             fix ci"
-      ]
+      "text/plain": "    Patch number                                        Patch title\n0          11713  minor: fix bug of empty position in windowed a...\n1          11702                             minor: fix npe in iqv2\n2          11696  minor: fix bug in abstractfetchermanagertest o...\n3          11686  kafka-12648: invoke exception handler for miss...\n4          11668  minor: fix confusion between eventqueueprocess...\n5          11666  kafka-13591- fix flaky test `controllerintegra...\n6          11665  kafka-13585- fix flaky test `replicamanagertes...\n7          11657  kafka-13552: fix broker and broker_logger in k...\n8          11625  minor: fix malformed html in javadoc of `scram...\n9          11611     minor: prefix topics if internal config is set\n10         11609  kafka-12648: fixes for query apis with named t...\n11         11607  kafka-13544: fix finalizedfeaturechangelistene...\n12         11605  minor: replace lastoption call in locallog#flu...\n13         11602  minor: reset java.security.auth.login.config i...\n14         11600  kafka-12648: handle missingsourcetopicexceptio...\n15         11597  kafka-13539: improve propagation and processin...\n16         11591  kafka-12648: fix illegalstateexception in clie...\n17         11590  hotfix: fix failing streamsmetadatastatetest t...\n18         11587   hotfix: bump version of grgit fro 4.1.0 to 4.1.1\n19         11577    kafka-13515: fix kraft config validation issues\n20         11574            minor: fix internal topic manager tests\n21         11563  kafka-13461: don't re-initialize zk client ses...\n22         11554  hotfix: set version of jgit to avoid unsupport...\n23         11552  kafka-13488: producer fails to recover if topi...\n24         11532  minor: fix system test test_upgrade_to_coopera...\n25         11519  minor: update error log in `defaultsslenginefa...\n26         11512  minor: modify the exception type of the testco...\n27         11510       minor: fix `client.quota.callback.class` doc\n28         11504  kafka-13457: socketchannel in acceptor#accept ...\n29         11501                   minor: fix fetchsessionbenchmark",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Patch number</th>\n      <th>Patch title</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>11713</td>\n      <td>minor: fix bug of empty position in windowed a...</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>11702</td>\n      <td>minor: fix npe in iqv2</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>11696</td>\n      <td>minor: fix bug in abstractfetchermanagertest o...</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>11686</td>\n      <td>kafka-12648: invoke exception handler for miss...</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>11668</td>\n      <td>minor: fix confusion between eventqueueprocess...</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>11666</td>\n      <td>kafka-13591- fix flaky test `controllerintegra...</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>11665</td>\n      <td>kafka-13585- fix flaky test `replicamanagertes...</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>11657</td>\n      <td>kafka-13552: fix broker and broker_logger in k...</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>11625</td>\n      <td>minor: fix malformed html in javadoc of `scram...</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>11611</td>\n      <td>minor: prefix topics if internal config is set</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>11609</td>\n      <td>kafka-12648: fixes for query apis with named t...</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11607</td>\n      <td>kafka-13544: fix finalizedfeaturechangelistene...</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>11605</td>\n      <td>minor: replace lastoption call in locallog#flu...</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>11602</td>\n      <td>minor: reset java.security.auth.login.config i...</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>11600</td>\n      <td>kafka-12648: handle missingsourcetopicexceptio...</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>11597</td>\n      <td>kafka-13539: improve propagation and processin...</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>11591</td>\n      <td>kafka-12648: fix illegalstateexception in clie...</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>11590</td>\n      <td>hotfix: fix failing streamsmetadatastatetest t...</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>11587</td>\n      <td>hotfix: bump version of grgit fro 4.1.0 to 4.1.1</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>11577</td>\n      <td>kafka-13515: fix kraft config validation issues</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>11574</td>\n      <td>minor: fix internal topic manager tests</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>11563</td>\n      <td>kafka-13461: don't re-initialize zk client ses...</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>11554</td>\n      <td>hotfix: set version of jgit to avoid unsupport...</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>11552</td>\n      <td>kafka-13488: producer fails to recover if topi...</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>11532</td>\n      <td>minor: fix system test test_upgrade_to_coopera...</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>11519</td>\n      <td>minor: update error log in `defaultsslenginefa...</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>11512</td>\n      <td>minor: modify the exception type of the testco...</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>11510</td>\n      <td>minor: fix `client.quota.callback.class` doc</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>11504</td>\n      <td>kafka-13457: socketchannel in acceptor#accept ...</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>11501</td>\n      <td>minor: fix fetchsessionbenchmark</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -657,7 +622,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There were three problems encountered: 
1. ```Http Error 401: Unauthorized```
2. ```string indices must be integers```
3. Incorrect ordering of parameters in the PR API (minor bug)

I have annotated the changes in the code with comments in the file ```Methods/patchExtractionFunctions.py```. 
Below is a summary.

Problem 1
======
```Http Error 401: Unauthorized```
I discovered that the library ```urllib.request``` was the main cause of the issue related to ```Http Error 401: Unauthorized``` 
Therefore, I replaced the library ```urllib.request``` with ```requests``` and adapted the code in the ```get_response(url, token_list, ct)``` method.

Problem 2
======
```string indices must be integers```
I just got a workaround for the issue since I did not have time to dig deep.
I discovered that some PRs in the repo pair ```apache/kafka->linkedin/kafka``` were causing the error  ```string indices must be integers```. I created a ```try``` and ```except``` block to ignore the specific pull requests. Incidentally, this problem is only on selected PRs in since others executed normally. The error does not exist in the repo pairs ```learningequality/pycaption->pbs/pycaption``` and ```hzdg/django-enumfields->druids/django-choice-enumfields```

Problem 3
======
The PR API that extracts the Pull requests from GitHub (i.e., ```url = 'https://api.github.com/repos/' + repo + '/pulls? [...]```) had the incorrect ordering of the parameters causing the request to return an array of 30 PRs (default) instead of 100. The updated code fixes this minor bug


